### PR TITLE
fixed typo in scene

### DIFF
--- a/aiopvapi/scenes.py
+++ b/aiopvapi/scenes.py
@@ -45,4 +45,4 @@ class Scenes:
         :param scene_id: The id of the scene.
         :returns: Nothing.
         """
-        yield from self.request.get(self._scenes_path, {"sceneid": scene_id})
+        yield from self.request.get(self._scenes_path, {"sceneId": scene_id})


### PR DESCRIPTION
This is a fix for #1, a typo in "sceneId" in 1.4 version. should probably me merged into a new branch.