### PR TITLE
Drop loop= kwarg from async_timeout and ClientSession calls

### DIFF
--- a/aiopvapi/helpers/aiorequest.py
+++ b/aiopvapi/helpers/aiorequest.py
@@ -48,7 +48,7 @@ class AioRequest:
         if websession:
             self.websession = websession
         else:
-            self.websession = aiohttp.ClientSession(loop=self.loop)
+            self.websession = aiohttp.ClientSession()
 
     async def get(self, url: str, params: str = None) -> dict:
         """
@@ -62,7 +62,7 @@ class AioRequest:
         response = None
         try:
             _LOGGER.debug("Sending GET request to: %s" % url)
-            with async_timeout.timeout(self._timeout, loop=self.loop):
+            with async_timeout.timeout(self._timeout):
                 response = await self.websession.get(url, params=params)
                 return await check_response(response, [200, 204])
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:
@@ -75,7 +75,7 @@ class AioRequest:
     async def post(self, url: str, data: dict = None):
         response = None
         try:
-            with async_timeout.timeout(self._timeout, loop=self.loop):
+            with async_timeout.timeout(self._timeout):
                 _LOGGER.debug("url: %s", url)
                 _LOGGER.debug("data: %s", data)
                 response = await self.websession.post(url, json=data)
@@ -97,7 +97,7 @@ class AioRequest:
         """
         response = None
         try:
-            with async_timeout.timeout(self._timeout, loop=self.loop):
+            with async_timeout.timeout(self._timeout):
                 _LOGGER.debug("url: %s", url)
                 _LOGGER.debug("data: %s", data)
                 response = await self.websession.put(url, json=data)
@@ -121,7 +121,7 @@ class AioRequest:
         """
         response = None
         try:
-            with async_timeout.timeout(self._timeout, loop=self.loop):
+            with async_timeout.timeout(self._timeout):
                 response = await self.websession.delete(url, params=params)
             return await check_response(response, [200, 204])
         except (asyncio.TimeoutError, aiohttp.ClientError) as error:


### PR DESCRIPTION
- async_timeout 4.0.0 drops the loop= kwarg and will fail if its passed

Fixes:
```
2021-11-04 15:12:13 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue for hunterdouglas_powerview using this method at homeassistant/components/hunterdouglas_powerview/__init__.py, line 102: shade_entries = await shades.get_resources()
2021-11-04 15:13:13 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue for hunterdouglas_powerview using this method at homeassistant/components/hunterdouglas_powerview/__init__.py, line 102: shade_entries = await shades.get_resources()
2021-11-04 15:14:13 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue for hunterdouglas_powerview using this method at homeassistant/components/hunterdouglas_powerview/__init__.py, line 102: shade_entries = await shades.get_resources()
2021-11-04 15:15:13 WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_timeout.timeout with loop keyword argument. The loop keyword argument is deprecated and calls will fail after Home Assistant 2022.2. Please report issue for hunterdouglas_powerview using this method at homeassistant/components/hunterdouglas_powerview/__init__.py, line 102: shade_entries = await shades.get_resources()
```