### PR TITLE
Add endpoints and handle 423 response

### DIFF
--- a/aiopvapi/__version__.py
+++ b/aiopvapi/__version__.py
@@ -1,3 +1,3 @@
 """Aio PowerView api version."""
 
-__version__ = "1.6.15"
+__version__ = "1.6.16"

--- a/aiopvapi/helpers/aiorequest.py
+++ b/aiopvapi/helpers/aiorequest.py
@@ -26,7 +26,7 @@ class PvApiConnectionError(PvApiError):
 
 async def check_response(response, valid_response_codes):
     """Check the response for correctness."""
-    if response.status == 204:
+    if response.status in [204, 423]:
         return True
     if response.status in valid_response_codes:
         _js = await response.json()

--- a/aiopvapi/resources/shade.py
+++ b/aiopvapi/resources/shade.py
@@ -107,6 +107,10 @@ class BaseShade(ApiResource):
         """Jog the shade."""
         await self.request.put(self._resource_path, {"shade": {"motion": "jog"}})
 
+    async def calibrate(self):
+        """Calibrate the shade."""
+        await self.request.put(self._resource_path, {"shade": {"motion": "calibrate"}})
+
     async def stop(self):
         """Stop the shade."""
         return await self.request.put(self._resource_path, {"shade": {"motion": "stop"}})
@@ -127,6 +131,12 @@ class BaseShade(ApiResource):
         """Query the hub and the actual shade to get the most recent shade
         data. Including current shade position."""
         raw_data = await self.request.get(self._resource_path, {"refresh": "true"})
+
+        self._raw_data = raw_data[ATTR_SHADE]
+
+    async def refreshBattery(self):
+        """Query the hub and request the most recent battery state."""
+        raw_data = await self.request.get(self._resource_path, {"updateBatteryLevel": "true"})
 
         self._raw_data = raw_data[ATTR_SHADE]
 


### PR DESCRIPTION
I have added two endpoints to use in next iteration of Home Assistant Integration to prevent issues accessing a protected member.

Endpoints have been tested with the new version and work as intended

Also added handling of 423 as mentioned here https://github.com/sander76/aio-powerview-api/pull/13
Reading the documentation i treated 423 as a 204 as the response is No Content anyway

Version bumped as i will need the version incremented for the HA release