### PR TITLE
Add model type 72 (Silhouette)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,3 +83,7 @@ Changelog
 
 **v3.1.1**
 - Fix missed timeout blocks and handle in websession
+
+**v3.1.2**
+
+- Add type 72 (Silhoutte)

--- a/aiopvapi/resources/shade.py
+++ b/aiopvapi/resources/shade.py
@@ -755,6 +755,7 @@ class ShadeBottomUpTiltOnClosed90(BaseShadeTilt):
         ShadeType(18, "Pirouette"),
         ShadeType(23, "Silhouette"),
         ShadeType(43, "Facette"),
+        ShadeType(72, "Silhouette"),
     )
 
     capability = ShadeCapability(

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ Shades not listed will get their features from their **capabilities**, unfortuna
 | Provenance Woven Wood                 |  19  |      0     |
 | Roman                                 |   4  |      0     |
 | Silhouette                            |  23  |      1     |
+| Silhouette                            |  72  |      1     |
 | Silhouette Duolite                    |  38  |      9     |
 | Sonnette                              |  53  |      0     |
 | Skyline Panel, Left Stack             |  26  |      3     |


### PR DESCRIPTION
Added model type 72 (Silhouette) to ShadeBottomUpTiltOnClosed90 as capability reported by this blind is incorrect. 

Fixes issue #40 