### PR TITLE
feat: add shade_ids property to Scene class

### DIFF
--- a/aiopvapi/resources/automation.py
+++ b/aiopvapi/resources/automation.py
@@ -60,8 +60,8 @@ class Automation(ApiResource):
         return self._raw_data.get(ATTR_SCENE_ID)
 
     @property
-    def room_id(self) -> int | None:
-        """Return the room id of the automation."""
+    def room_id(self) -> list[int] | None:
+        """Return the room id(s) of the automation."""
         return self._room_id
 
     def convert_to_12_hour(self, hour: int):

--- a/aiopvapi/resources/scene.py
+++ b/aiopvapi/resources/scene.py
@@ -28,6 +28,13 @@ class Scene(ApiResource):
         super().__init__(request, self.api_endpoint, raw_data)
 
     @property
+    def shade_ids(self) -> list[int]:
+        """Return shade ids for gen3 hubs, empty list otherwise."""
+        if self.api_version >= 3:
+            return self._raw_data.get(ATTR_SHADE_IDS, [])
+        return []
+
+    @property
     def room_id(self):
         """Return the room id."""
         if self.api_version >= 3:

--- a/aiopvapi/resources/scene.py
+++ b/aiopvapi/resources/scene.py
@@ -35,11 +35,11 @@ class Scene(ApiResource):
         return []
 
     @property
-    def room_id(self):
-        """Return the room id."""
+    def room_id(self) -> list[int]:
+        """Return the id of room(s) associated with this scene."""
         if self.api_version >= 3:
-            return self._raw_data.get(ATTR_ROOM_IDS)[0]
-        return self._raw_data.get(ATTR_ROOM_ID)
+            return self._raw_data.get(ATTR_ROOM_IDS, [])
+        return [self._raw_data.get(ATTR_ROOM_ID)]
 
     async def activate(self) -> list[int]:
         """Activate this scene."""

--- a/aiopvapi/scene_members.py
+++ b/aiopvapi/scene_members.py
@@ -11,6 +11,7 @@ from aiopvapi.helpers.constants import (
     SCENE_MEMBER_DATA,
 )
 from aiopvapi.resources.model import PowerviewData
+from aiopvapi.resources.scene import Scene
 from aiopvapi.resources.scene_member import ATTR_SCENE_MEMBER, SceneMember
 
 _LOGGER = logging.getLogger("__name__")
@@ -80,3 +81,34 @@ class SceneMembers(ApiEntryPoint):
         }
 
         return PowerviewData(raw=resources, processed=processed)
+
+
+def build_shade_scene_mapping(
+    scene_data: PowerviewData,
+    scene_member_data: PowerviewData | None = None,
+) -> tuple[dict[int, list[int]], dict[int, list[int]]]:
+    """Build bidirectional shade↔scene ID mappings.
+
+    Pass scene_member_data for gen2 hubs (from SceneMembers.get_scene_members()).
+    For gen3, shadeIds are embedded in scene data and scene_member_data is not needed.
+
+    Returns (scene_to_shade_ids, shade_to_scene_ids).
+    """
+    scene_to_shade_ids: dict[int, list[int]] = {}
+    shade_to_scene_ids: dict[int, list[int]] = {}
+
+    if scene_member_data is not None:
+        for member in scene_member_data.raw:
+            s_id = member["sceneId"]
+            sh_id = member["shadeId"]
+            scene_to_shade_ids.setdefault(s_id, []).append(sh_id)
+            shade_to_scene_ids.setdefault(sh_id, []).append(s_id)
+    else:
+        for scene in scene_data.processed.values():
+            if not isinstance(scene, Scene):
+                continue
+            for sh_id in scene.shade_ids:
+                scene_to_shade_ids.setdefault(scene.id, []).append(sh_id)
+                shade_to_scene_ids.setdefault(sh_id, []).append(scene.id)
+
+    return scene_to_shade_ids, shade_to_scene_ids

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -42,6 +42,26 @@ class TestScene(TestApiResource):
     def test_room_id_property(self):
         self.assertEqual(26756, self.resource.room_id)
 
+    def test_shade_ids_v2_returns_empty(self):
+        self.assertEqual([], self.resource.shade_ids)
+
+    def test_shade_ids_v3_returns_ids(self):
+        _request = Mock(spec=AioRequest)
+        _request.hub_ip = FAKE_BASE_URL
+        _request.api_version = 3
+        _request.api_path = "api"
+        raw_data = {**SCENE_RAW_DATA, "shadeIds": [1, 2, 3]}
+        scene = Scene(raw_data, _request)
+        self.assertEqual([1, 2, 3], scene.shade_ids)
+
+    def test_shade_ids_v3_missing_returns_empty(self):
+        _request = Mock(spec=AioRequest)
+        _request.hub_ip = FAKE_BASE_URL
+        _request.api_version = 3
+        _request.api_path = "api"
+        scene = Scene(SCENE_RAW_DATA, _request)
+        self.assertEqual([], scene.shade_ids)
+
     def test_full_path(self):
         self.assertEqual(
             self.resource.base_path,

--- a/tests/test_scene.py
+++ b/tests/test_scene.py
@@ -40,7 +40,7 @@ class TestScene(TestApiResource):
         self.assertEqual("Dining Vanes Open", self.resource.name)
 
     def test_room_id_property(self):
-        self.assertEqual(26756, self.resource.room_id)
+        self.assertEqual([26756], self.resource.room_id)
 
     def test_shade_ids_v2_returns_empty(self):
         self.assertEqual([], self.resource.shade_ids)


### PR DESCRIPTION
Exposes shadeIds from gen3 scene data via a proper property instead of requiring consumers to access raw_data directly. Returns empty list for API versions < 3.

Fixes sander76/aio-powerview-api#49